### PR TITLE
remove + and 00 from recipient number and change baseEncode value

### DIFF
--- a/src/Clients/UnifonicClient.php
+++ b/src/Clients/UnifonicClient.php
@@ -47,8 +47,8 @@ class UnifonicClient
             'AppSid' => $this->appSid,
             'SenderID' => $sender,
             'Body' => $message,
-            'Recipient' => str_replace('+', "00", $recipient),
-            'baseEncode' => false,
+            'Recipient' => preg_replace('/^\+|^00/', '', $recipient),
+            'baseEncode' => true,
             "MessageType" => $this->messageType,
             "statusCallback" => "sent"
         ];


### PR DESCRIPTION
Changes: (Unifonic)

- Removed leading '+' and '00' from the recipient number to ensure compatibility.
- Updated baseEncode value to maintain consistency across the codebase.